### PR TITLE
fix potentially missing commas

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 aws_cwa_dest_path: /opt/aws/amazon-cloudwatch-agent
 aws_cwa_logfile_path: /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
+aws_cwa_metrics_collection_interval: 300

--- a/templates/cwa_config.json.j2
+++ b/templates/cwa_config.json.j2
@@ -1,6 +1,6 @@
 {
     "agent": {
-        "metrics_collection_interval": 300,
+        "metrics_collection_interval": {{ aws_cwa_metrics_collection_interval }},
         "logfile": "{{ aws_cwa_logfile_path }}"
     }{% if aws_cwa_logfiles|length > 0 %},
 
@@ -19,7 +19,7 @@
                         {% if logfile.timezone is defined %},"timezone": "{{ logfile.timezone }}"
                         {%- endif -%}
                         {% if logfile.multi_line_start_pattern is defined %},"multi_line_start_pattern": "{{ logfile.multi_line_start_pattern }}"
-                        {%- endif -%}         
+                        {%- endif -%}
                         {% if logfile.encoding is defined %},"encoding": "{{ logfile.encoding }}"
                         {%- endif -%}
                     }{% if not loop.last %},{% endif -%}

--- a/templates/cwa_config.json.j2
+++ b/templates/cwa_config.json.j2
@@ -13,18 +13,14 @@
                         "file_path": "{{ logfile.file_path }}",
                         "log_group_name": "{{ logfile.log_group_name }}",
                         "log_stream_name": "{{ logfile.stream_name | default('{local_hostname}') }}"
-                        {% if logfile.timestamp_format is defined %},"timestamp_format": "{{ logfile.timestamp_format }}"{% if logfile.timezone is defined %},{% endif %}
+                        {% if logfile.timestamp_format is defined %},"timestamp_format": "{{ logfile.timestamp_format }}"
                         {% endif %}
 
-                        {% if logfile.timezone is defined %}"timezone": "{{ logfile.timezone }}"
-                            {% if logfile.multi_line_start_pattern is defined %},
-                            {% endif %}
+                        {% if logfile.timezone is defined %},"timezone": "{{ logfile.timezone }}",
                         {%- endif -%}
-                        {% if logfile.multi_line_start_pattern is defined %}"multi_line_start_pattern": "{{ logfile.multi_line_start_pattern }}"
-                            {% if logfile.encoding is defined %},
-                            {% endif %}
+                        {% if logfile.multi_line_start_pattern is defined %},"multi_line_start_pattern": "{{ logfile.multi_line_start_pattern }}"
                         {%- endif -%}         
-                        {% if logfile.encoding is defined %}"encoding": "{{ logfile.encoding }}"
+                        {% if logfile.encoding is defined %},"encoding": "{{ logfile.encoding }}"
                         {%- endif -%}
                     }{% if not loop.last %},{% endif -%}
                 {% endfor %}]

--- a/templates/cwa_config.json.j2
+++ b/templates/cwa_config.json.j2
@@ -16,7 +16,7 @@
                         {% if logfile.timestamp_format is defined %},"timestamp_format": "{{ logfile.timestamp_format }}"
                         {% endif %}
 
-                        {% if logfile.timezone is defined %},"timezone": "{{ logfile.timezone }}",
+                        {% if logfile.timezone is defined %},"timezone": "{{ logfile.timezone }}"
                         {%- endif -%}
                         {% if logfile.multi_line_start_pattern is defined %},"multi_line_start_pattern": "{{ logfile.multi_line_start_pattern }}"
                         {%- endif -%}         


### PR DESCRIPTION
for example, if `timezone` is set while `timestamp_format` isn't,
there will be no comma before `"timezone"` in the generated file.
This means the resulting json file will be invalid, as tested by @fahziar 
```json
                "collect_list": [
                    {
                        // ...
                        "log_stream_name": "'{local_hostname}'"              
                        "timezone": "UTC"
                    }]
```
cc @ronny-kaluge 