### PR TITLE
configurable metric collection interval

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 aws_cwa_dest_path: /opt/aws/amazon-cloudwatch-agent
 aws_cwa_logfile_path: /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log
+aws_cwa_metrics_collection_interval: 300

--- a/templates/cwa_config.json.j2
+++ b/templates/cwa_config.json.j2
@@ -1,6 +1,6 @@
 {
     "agent": {
-        "metrics_collection_interval": 300,
+        "metrics_collection_interval": {{ aws_cwa_metrics_collection_interval }},
         "logfile": "{{ aws_cwa_logfile_path }}"
     }{% if aws_cwa_logfiles|length > 0 %},
 
@@ -19,7 +19,7 @@
                         {% if logfile.timezone is defined %},"timezone": "{{ logfile.timezone }}"
                         {%- endif -%}
                         {% if logfile.multi_line_start_pattern is defined %},"multi_line_start_pattern": "{{ logfile.multi_line_start_pattern }}"
-                        {%- endif -%}         
+                        {%- endif -%}
                         {% if logfile.encoding is defined %},"encoding": "{{ logfile.encoding }}"
                         {%- endif -%}
                     }{% if not loop.last %},{% endif -%}


### PR DESCRIPTION
It seems the value of `metrics_collection_interval` has to be the same across cwa config files.
A system might already have other config files (e.g. for syslog), which set `metrics_collection_interval` to values other than the previous default (300)

Therefore, this should be a variable
